### PR TITLE
Experiment trackers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@
 demos/**/poetry.lock
 demos/**/pyproject.toml
 
+# wandb
+**wandb/
+!src/coalescenceml/integrations/wandb
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/demos/mlflow/pipeline.py
+++ b/demos/mlflow/pipeline.py
@@ -1,0 +1,137 @@
+from typing import Optional
+
+import mlflow
+import numpy as np
+from sklearn.datasets import load_breast_cancer
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.metrics import accuracy_score
+from sklearn.model_selection import train_test_split
+
+from coalescenceml.integrations.constants import MLFLOW, SKLEARN
+from coalescenceml.integrations.mlflow.mlflow_step_decorator import enable_mlflow
+from coalescenceml.pipeline import pipeline
+from coalescenceml.step import BaseStepConfig, Output, step
+
+
+@step
+def import_data() -> Output(
+    x_train=np.ndarray, y_train=np.ndarray,
+    x_test=np.ndarray, y_test=np.ndarray,
+):
+    X, Y = load_breast_cancer(return_X_y=True)
+    x_train, x_test, y_train, y_test = train_test_split(X, Y, test_size=0.3, random_state=0)
+    return x_train, y_train, x_test, y_test
+
+
+class RandomForestConfig(BaseStepConfig):
+    n_estimators: int = 100
+    criterion: str = "gini"
+    max_depth: Optional[int] = None
+    min_samples_split: int = 2
+
+
+@enable_mlflow
+@step
+def trainer(
+    config: RandomForestConfig,
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+) -> Output(model=RandomForestClassifier):
+    mlflow.sklearn.autolog()
+
+    model = RandomForestClassifier(**config.dict())
+    model.fit(x_train, y_train)
+
+    return model
+
+
+@enable_mlflow
+@step
+def evaluator(
+    model: RandomForestClassifier,
+    x_test: np.ndarray,
+    y_test: np.ndarray,
+) -> Output(acc=float):
+    preds = model.predict(x_test)
+    test_acc = accuracy_score(y_test, preds)
+    mlflow.log_metrics({"test_acc": test_acc})
+    return test_acc
+
+
+@pipeline(enable_cache=False, required_integrations=[MLFLOW, SKLEARN])
+def mlflow_example_pipeline(
+    importer,
+    trainer,
+    evaluator,
+):
+    x_train, y_train, x_test, y_test = importer()
+    model = trainer(x_train, y_train)
+    evaluator(model, x_test, y_test)
+
+
+def get_tracking_uri() -> str:
+    from coalescenceml.directory import Directory
+
+    tracker = Directory().active_stack.experiment_tracker
+
+    return tracker.get_tracking_uri()
+
+if __name__ == '__main__':
+    config_1 = RandomForestConfig(
+    )
+
+    config_2 = RandomForestConfig(
+        n_estimators=200,
+    )
+
+    config_3 = RandomForestConfig(
+        n_estimators=50,
+    )
+
+    config_4 = RandomForestConfig(
+        max_depth=10,
+    )
+    
+    config_5 = RandomForestConfig(
+        max_depth=5,
+    )
+
+    config_6 = RandomForestConfig(
+        n_estimators=200,
+        max_depth=5,
+    )
+
+    config_7 = RandomForestConfig(
+        n_estimators=50,
+        max_depth=10,
+    )
+
+    config_8 = RandomForestConfig(
+        n_estimators=100,
+        max_depth=15,
+    )
+
+    configs = [
+        config_1,
+        config_2,
+        config_3,
+        config_4,
+        config_5,
+        config_6,
+        config_7,
+        config_8,
+    ]
+
+    for cfg in configs:
+        pipe = mlflow_example_pipeline(
+            importer=import_data(),
+            trainer=trainer(config=cfg),
+            evaluator=evaluator(),
+        )
+        pipe.run()
+
+    print(
+        "Now run\n "
+        f"mlflow ui --backend-store-uri {get_tracking_uri()}\n"
+        "to inspect the experiment runs within the MLFlow UI."
+    )

--- a/demos/mlflow/pipeline_tf.py
+++ b/demos/mlflow/pipeline_tf.py
@@ -1,0 +1,166 @@
+import mlflow
+import numpy as np
+import tensorflow as tf
+
+from coalescenceml.integrations.constants import MLFLOW, TENSORFLOW
+from coalescenceml.integrations.mlflow.mlflow_step_decorator import enable_mlflow
+from coalescenceml.pipelines import pipeline
+from coalescenceml.step import BaseStepConfig, Output, step
+
+
+@step
+def import_mnist() -> Output(
+    x_train=np.ndarray, y_train=np.ndarray,
+    x_test=np.ndarray, y_test=np.ndarray,
+):
+    (
+        (x_train, y_train),
+        (x_test, y_test),
+    ) = tf.keras.datasets.mnist.load_data()
+    return x_train, y_train, x_test, y_test
+
+
+@step
+def normalize(
+    x_train: np.ndarray, x_test: np.ndarray,
+) -> Output(
+    x_train_normalized=np.ndarray,
+    x_test_normalized=np.ndarray,
+):
+    x_train_normalized = x_train / 255.
+    x_test_normalized = x_test / 255.
+    return x_train_normalized, x_test_normalized
+
+
+class TFTrainerConfig(BaseStepConfig):
+    epochs: int = 5
+    batch_size: int = 32
+    lr: float = 1e-3
+    momentum: float = 0.9
+
+
+@enable_mlflow
+@step
+def tf_trainer(
+    config: TFTrainerConfig,
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+) -> Output(model=tf.keras.Model):
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Flatten(input_shape=(28,28)),
+            tf.keras.layers.Dense(512, activation='relu'),
+            tf.keras.layers.Dense(10, activation='linear'),
+        ]
+    )
+
+    model.compile(
+        optimizer=tf.keras.optimizers.SGD(
+            learning_rate=config.lr,
+            momentum=config.momentum,
+        ),
+        loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=["accuracy"],
+    )
+
+    mlflow.tensorflow.autolog()
+    model.fit(
+        x_train,
+        y_train,
+        epochs=config.epochs,
+        batch_size=config.batch_size,
+    )
+
+    return model
+
+
+@enable_mlflow
+@step
+def tf_evaluator(
+    model: tf.keras.Model,
+    x_test: np.ndarray,
+    y_test: np,ndarray,
+) -> Output(acc=float):
+    _, test_acc = model.evaluate(x_test, y_test)
+    mlflow.log_metrics({"test_acc": test_acc})
+    return test_acc
+
+
+@pipeline(enable_cache=False, required_integrations=[MLFLOW, TENSORFLOW])
+def mlflow_example_pipeline(
+    importer,
+    normalize,
+    trainer,
+    evaluator,
+):
+    x_train, y_train, x_test, y_test = import_mnist()
+    x_tr_normalized, x_te_normalized = normalize(x_train, x_test)
+    model = trainer(x_tr_normalized, y_train)
+    evaluator(model, x_tr_normalized, y_test)
+
+
+def get_tracking_uri() -> str:
+    from coalescenceml.directory import Directory
+
+    tracker = Directory().active_stack.experiment_tracker
+
+    return tracker.get_tracking_uri()
+
+if __name__ == '__main__':
+    config_1 = TFTrainerConfig(
+        lr=1e-1,
+    )
+
+    config_2 = TFTrainerConfig(
+        lr=1e-2,
+    )
+
+    config_3 = TFTrainerConfig(
+        lr=1e-3,
+    )
+
+    config_4 = TFTrainerConfig(
+        batch_size=64,
+    )
+    
+    config_5 = TFTrainerConfig(
+        batch_size=32,
+    )
+
+    config_6 = TFTrainerConfig(
+        batch_size=16,
+    )
+
+    config_7 = TFTrainerConfig(
+        epochs=10,
+    )
+
+    config_8 = TFTrainerConfig(
+        epochs=20,
+    )
+
+    configs = [
+        config_1,
+        config_2,
+        config_3,
+        config_4,
+        config_5,
+        config_6,
+        config_7,
+        config_8,
+    ]
+
+    for cfg in configs:
+        pipe = mlflow_example_pipeline(
+            importer=import_mnist(),
+            normalize=normalize(),
+            trainer=tf_trainer(config=config_1),
+            evaluator=tf_evaluator(),
+        )
+        pipe.run()
+
+    print(
+        "Now run\n "
+        f"mlflow ui --backend-store-uri {get_tracking_uri()}\n"
+        "to inspect the experiment runs within the MLFlow UI."
+    )

--- a/demos/wandb_tracking/pipeline.py
+++ b/demos/wandb_tracking/pipeline.py
@@ -1,0 +1,117 @@
+import numpy as np
+import tensorflow as tf
+import wandb
+from wandb.keras import WandbCallback
+
+from coalescenceml.integrations.contants import TENSORFLOW, WANDB
+from coalescenceml.integrations.wandb.wandb_step_decorator import enable_wandb
+from coalescenceml.pipeline import pipeline
+from coalescenceml.step import BaseStepConfig, Output, step
+
+
+class TFTrainerConfig(BaseStepConfig):
+    """Trainer parameters."""
+
+    epochs: int = 1
+    lr: float = 1e-3
+
+
+@step
+def import_mnist() -> Output(
+    x_train=np.ndarray, y_train=np.ndarray,
+    x_test=np.ndarray, y_test=np.ndarray,
+):
+    (x_train, y_train), (x_test, y_test) = tf.keras.datasets.mnist.load_data()
+    return x_train, y_train, x_test, y_test
+
+
+@step
+def normalize(
+    x_train: np.ndarray, x_test: np.ndarray,
+) -> Output(x_train_normalized=np.ndarray, x_test_normalized=np.ndarray,):
+    x_train_normalized = x_train / 255.0
+    x_test_normalized = x_test / 255.0
+    return x_train_normalized, x_test_normalized
+
+
+@enable_wandb
+@step
+def tf_trainer(
+    config: TFTrainerConfig,
+    x_train: np.ndarray,
+    y_train: np.ndarray,
+    x_val: np.ndarray,
+    y_val: np.ndarray,
+)-> Output(model=tf.keras.Model):
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Flatten(input_shape=(28,28)),
+            tf.keras.layers.Dense(10),
+        ]
+    )
+
+    model.compile(
+        optimizer=tf.keras.optimizers.SGD(learning_rate=config.lr, momentum=0.9),
+        loss=tf.keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=["accuracy"]
+    )
+
+    model.fit(
+        x_train,
+        y_train,
+        epochs=config.epochs,
+        validation_data=(x_val, y_val),
+        callbacks=[
+            WandbCallback(
+                log_evaluation=True,
+                validation_steps=16,
+                validation_data=(x_val, y_val)
+            )
+        ],
+    )
+
+    return model
+
+
+@enable_wandb
+@step
+def tf_evaluation(
+    model: tf.keras.Model,
+    x_val: np.ndarray,
+    y_val: np.ndarray,
+) -> Output(accuracy=float):
+    _, val_acc = model.evaluate(x_val, y_val)
+    wandb.log({"val_accuracy": val_acc})
+    return val_acc
+
+
+@pipeline(enable_cache=False, required_integrations=[TENSORFLOW, WANDB])
+def wandb_sample_pipeline(
+    importer,
+    normalize,
+    trainer,
+    evaluator,
+):
+    x_train, y_train, x_test, y_test = importer()
+    x_train_normalized, x_test_normalized = normalize(x_train, x_test)
+    model = trainer(x_train, y_train, x_test, y_test)
+    val_acc = evaluator(model, x_test, y_test)
+
+
+if __name__ == '__main__':
+    pipe_1 = wandb_sample_pipeline(
+        import_mnist(),
+        normalize(),
+        tf_trainer(config=TFTrainerConfig(epochs=5, lr=3e-4)),
+        tf_evaluation(),
+    )
+    pipe_1.run()
+
+
+    pipe_2 = wandb_sample_pipeline(
+        import_mnist(),
+        normalize(),
+        tf_trainer(config=TFTrainerConfig(epochs=5, lr=1e-4)),
+        tf_evaluation(),
+    )
+    pipe_2.run()

--- a/src/coalescenceml/artifact_store/local_artifact_store.py
+++ b/src/coalescenceml/artifact_store/local_artifact_store.py
@@ -28,7 +28,7 @@ class LocalArtifactStore(BaseArtifactStore):
 
     # Class Configuration
     FLAVOR: ClassVar[str] = "local"
-    SUPPORTED_SCHEMES: ClassVar[Set[str]] = {""}
+    SUPPORTED_SCHEMES: ClassVar[Set[str]] = {"", "file://"}
 
     @staticmethod
     def open(name: PathType, mode: str = "r") -> Any:

--- a/src/coalescenceml/cli/stack.py
+++ b/src/coalescenceml/cli/stack.py
@@ -84,6 +84,14 @@ def stack() -> None:
     type=str,
     required=False,
 )
+@click.option(
+    "-e",
+    "--experiment-tracker",
+    "experiment_tracker_name",
+    help="Name of the experiment tracker for this stack.",
+    type=str,
+    required=False,
+)
 def register_stack(
     stack_name: str,
     metadata_store_name: str,
@@ -94,6 +102,7 @@ def register_stack(
     step_operator_name: Optional[str] = None,
     feature_store_name: Optional[str] = None,
     model_deployer_name: Optional[str] = None,
+    experiment_tracker_name: Optional[str] = None,
 ) -> None:
     """Register a stack."""
     cli_utils.print_active_profile()
@@ -150,6 +159,14 @@ def register_stack(
             ] = dir_.get_stack_component(
                 StackComponentFlavor.MODEL_DEPLOYER,
                 name=model_deployer_name,
+            )
+
+        if experiment_tracker_name:
+            stack_components[
+                StackComponentFlavor.EXPERIMENT_TRACKER
+            ] = dir_.get_stack_component(
+                StackComponentFlavor.EXPERIMENT_TRACKER,
+                name=experiment_tracker_name,
             )
 
         stack_ = Stack.from_components(

--- a/src/coalescenceml/constants.py
+++ b/src/coalescenceml/constants.py
@@ -8,7 +8,7 @@ from rich.theme import Theme
 coml_custom_theme = Theme(
     {
         "info": "dim cyan",
-        "warning": "magenta",
+        "warning": "yellow",
         "danger": "bold red",
         "error": "red",
         "title": "bold cyan underline",

--- a/src/coalescenceml/enums.py
+++ b/src/coalescenceml/enums.py
@@ -57,6 +57,7 @@ class StackComponentFlavor(DictEnum):
     ARTIFACT_STORE = "artifact_store"
     CONTAINER_REGISTRY = "container_registry"
     STEP_OPERATOR = "step_operator"  # TODO
+    EXPERIMENT_TRACKER = "experiment_tracker"
     #FEATURE_STORE = "feature_store"  # TODO
     #SECRETS_MANAGER = "secrets_manager"  # TODO
     #MODEL_DEPLOYER = "model_deployer"  # TODO

--- a/src/coalescenceml/environment.py
+++ b/src/coalescenceml/environment.py
@@ -251,9 +251,13 @@ class Environment(metaclass=SingletonMetaClass):
         Returns:
             The `StepEnvironment` that describes the current step.
         """
-        from coalescenceml.steps import STEP_ENVIRONMENT_NAME, StepEnvironment
+        from coalescenceml.step import STEP_ENVIRONMENT_NAME, StepEnvironment
 
         return cast(StepEnvironment, self[STEP_ENVIRONMENT_NAME])
+
+    @property
+    def step_env(self) -> "StepEnvironment":
+        return self.step_environment
 
 
 _BASE_ENVIRONMENT_COMPONENT_NAME = "base_environment_component"

--- a/src/coalescenceml/experiment_tracker/__init__.py
+++ b/src/coalescenceml/experiment_tracker/__init__.py
@@ -1,0 +1,16 @@
+"""
+## Experiment Trackers
+
+Experiment trackers help you track/log ML experiments by logging the
+parameters, metrics, and model artifacts which allows you to compare
+between runs. In general a single pipeline run is an experiment however,
+one can run a series of experiments within a single pipeline.
+"""
+
+from coalescenceml.experiment_tracker.base_experiment_tracker import (
+    BaseExperimentTracker,
+)
+
+__all__ = [
+    "BaseExperimentTracker",
+]

--- a/src/coalescenceml/experiment_tracker/base_experiment_tracker.py
+++ b/src/coalescenceml/experiment_tracker/base_experiment_tracker.py
@@ -1,0 +1,26 @@
+from abc import ABC, abstractmethod
+from typing import Any, ClassVar, Dict
+
+from coalescenceml.enums import StackComponentFlavor
+from coalescenceml.stack import StackComponent
+
+
+class BaseExperimentTracker(StackComponent, ABC):
+    """Base class for all CoalescenceML experiment trackers."""
+
+    # Class config
+    TYPE: ClassVar[StackComponentFlavor] = StackComponentFlavor.EXPERIMENT_TRACKER
+    FLAVOR: ClassVar[str]
+
+
+    @abstractmethod
+    def log_params(self, params: Dict[str, Any]) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def log_metrics(self, metrics: Dict[str, Any]) -> None:
+        raise NotImplementedError()
+
+    @abstractmethod
+    def log_artifacts(self, artifacts: Dict[str, Any]) -> None:
+        raise NotImplementedError()

--- a/src/coalescenceml/integrations/__init__.py
+++ b/src/coalescenceml/integrations/__init__.py
@@ -4,5 +4,6 @@ support. This includes orchestrators like Apache Airflow as well as deep
 learning libraries like PyTorch.
 """
 # Imports here when we have them lol
+from coalescenceml.integrations.mlflow import MLFlowIntegration
 from coalescenceml.integrations.sklearn import SKLearnIntegration
 from coalescenceml.integrations.statsmodels import StatsmodelsIntegration

--- a/src/coalescenceml/integrations/mlflow/__init__.py
+++ b/src/coalescenceml/integrations/mlflow/__init__.py
@@ -1,0 +1,20 @@
+from coalescenceml.integrations.constants import MLFLOW
+from coalescenceml.integrations.integration import Integration
+
+
+class MLFlowIntegration(Integration):
+    """MLFlow integration for CoalescenceML."""
+
+    NAME = MLFLOW
+    REQUIREMENTS = [
+        "mlflow==1.25.1",
+        "mlserver==1.0.1",
+        "mlserver-mlflow==1.0.1",
+    ]
+
+    @classmethod
+    def activate(cls) -> None:
+        from coalescenceml.integrations.mlflow import experiment_tracker
+
+
+MLFlowIntegration.check_installation()

--- a/src/coalescenceml/integrations/mlflow/experiment_tracker/__init__.py
+++ b/src/coalescenceml/integrations/mlflow/experiment_tracker/__init__.py
@@ -1,0 +1,3 @@
+from coalescenceml.integrations.mlflow.experiment_tracker.mlflow_experiment_tracker import (
+    MLFlowExperimentTracker,
+_

--- a/src/coalescenceml/integrations/mlflow/experiment_tracker/__init__.py
+++ b/src/coalescenceml/integrations/mlflow/experiment_tracker/__init__.py
@@ -1,3 +1,3 @@
 from coalescenceml.integrations.mlflow.experiment_tracker.mlflow_experiment_tracker import (
     MLFlowExperimentTracker,
-_
+)

--- a/src/coalescenceml/integrations/mlflow/experiment_tracker/mlflow_experiment_tracker.py
+++ b/src/coalescenceml/integrations/mlflow/experiment_tracker/mlflow_experiment_tracker.py
@@ -1,0 +1,65 @@
+from typing import Any, ClassVar, Dict
+
+import mlflow
+from mlflow.entities import Experiment
+from pydantic import validator
+
+
+from coalescenceml.directory import Directory
+from coalescenceml.environment import Environment
+from coalescenceml.experiment_tracker import (
+    BaseExperimentTracker,
+)
+from coalescenceml.integrations.constants import MLFLOW
+from coalescenceml.logger import get_logger
+from coalescenceml.stack.stack_component_class_registry import (
+    register_stack_component_class,
+)
+
+logger = get_logger(__name__)
+
+
+@register_stack_component_class
+class MLFlowExperimentTracker(BaseExperimentTracker):
+    """Stores MLFlow Configuration and interaction functions.
+
+    CoalescenceML configures MLFlow for you....
+    """
+    # TODO: Ask Iris about local mlflow runs
+    tracking_uri: Optional[str] = None # Can this
+    is_local: bool
+    tracking_token: Optional[str] = None # The way I prefer using MLFlow
+    tracking_username: Optional[str] = None
+    tracking_password: Optional[str] = None
+
+    FLAVOR: ClassVar[str] = MLFLOW
+
+    @validator("tracking_uri")
+    def ensure_valid_tracking_uri(
+        cls, tracking_uri: Optional[str] = None,
+    ) -> Optional[str]:
+        """Ensure the tracking uri is a valid mlflow tracking uri.
+
+        Args:
+            tracking_uri: The value to verify
+
+        Returns:
+            Valid tracking uri
+
+        Raises:
+            ValueError: if mlflow tracking uri is invalid.
+        """
+        if tracking_uri:
+            valid_protocols = DATABASE_ENGINES + ["http", "https", "file"]
+            if not any(
+                tracking_uri.startswith(protocol)
+                for protocol in valid_protocols
+            ):
+                raise ValueError(
+                    f"MLFlow tracking uri does not use a valid protocol "
+                    f" which inclue: {valid_protocols}. Please see "
+                    f"https://www.mlflow.org/docs/latest/tracking.html"
+                    f"#where-runs-are-recorded for more information."
+                )
+
+        return tracking_uri

--- a/src/coalescenceml/integrations/mlflow/experiment_tracker/mlflow_experiment_tracker.py
+++ b/src/coalescenceml/integrations/mlflow/experiment_tracker/mlflow_experiment_tracker.py
@@ -2,7 +2,7 @@ from typing import Any, ClassVar, Dict
 
 import mlflow
 from mlflow.entities import Experiment
-from pydantic import validator
+from pydantic import root_validator, validator
 
 
 from coalescenceml.directory import Directory
@@ -18,6 +18,13 @@ from coalescenceml.stack.stack_component_class_registry import (
 
 logger = get_logger(__name__)
 
+MLFLOW_TRACKING_TOKEN = "MLFLOW_TRACKING_TOKEN"
+MLFLOW_TRACKING_USERNAME = "MLFLOW_TRACKING_USERNAME"
+MLFLOW_TRACKING_PASSWORD = "MLFLOW_TRACKING_PASSWORD"
+# TODO: Determine whether to use insecure TLS
+# TODO: How do we use a cert bundle if desired?
+# https://www.mlflow.org/docs/latest/tracking.html#logging-to-a-tracking-server
+
 
 @register_stack_component_class
 class MLFlowExperimentTracker(BaseExperimentTracker):
@@ -27,7 +34,7 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
     """
     # TODO: Ask Iris about local mlflow runs
     tracking_uri: Optional[str] = None # Can this
-    is_local: bool
+    use_local_backend: bool = False # base it on tracking_uri
     tracking_token: Optional[str] = None # The way I prefer using MLFlow
     tracking_username: Optional[str] = None
     tracking_password: Optional[str] = None
@@ -63,3 +70,212 @@ class MLFlowExperimentTracker(BaseExperimentTracker):
                 )
 
         return tracking_uri
+
+    @staticmethod
+    def is_remote_tracking_uri(tracking_uri: str) -> bool:
+        """Check whether URI is using remote protocol.
+
+        Args:
+            tracking_uri: MLFlow tracking server location
+
+        Returns:
+            True if server is remote else False
+        """
+        return any(
+            tracking_uri.startswith(prefix)
+            for prefix in ["http", "https"]
+            # Only need these as tested with AWS MySQL generates hostname
+            # with HTTP. Hence any cloud servers will have to have http and 
+            # local ones do not. But this might be wrong and need to change.
+        )
+
+    @root_validator
+    def ensure_tracking_uri_or_local(cls, values: Dict[str, Any]) -> Dict[str, Any]:
+        """Ensure that the tracking uri exists or use local backend is true.
+
+        Args:
+            values: Pydantic stored values of class
+
+        Returns:
+            Pydantic class values
+        """
+        tracking_uri = values.get("tracking_uri")
+        use_local_backend = values.get("use_local_backend")
+
+        if not (tracking_uri or use_local_backend):
+            raise ValueError(
+                f"You must specify either a tracking uri or the use "
+                f"your local artifact store for the MLFlow "
+                f"experiment tracker."
+                # TODO: Message on how to fix.
+            )
+
+
+    @root_validator
+    def ensure_authentication(
+        cls, values: Dict[str, Any],
+    ) -> Dict[str, Any]:
+        """Ensure that credentials exists for a remote tracking instance.
+
+        Args:
+            values: Pydantic stored values of class
+
+        Returns:
+            class pydantic values
+        """
+        tracking_uri = values.get("tracking_uri")
+
+        if tracking_uri: # Check if exists
+            if cls.is_remote_tracking_uri(tracking_uri): # Check if remote
+                token_auth = values.get("tracking_token")
+
+                basic_http_auth = (
+                    values.get("tracking_username")
+                    and values.get("tracking_password")
+                )
+
+                if not (token_auth or basic_http_auth):
+                    raise ValueError(
+                        f"MLFlow experiment tracking with a remote tracking "
+                        f"uri '{tracking_uri}' is only allowed when either a "
+                        f"username and password or auth token is used."
+                        # TODO: Add update commands to stack to all users to update the component.
+                    )
+
+        return values
+
+    @staticmethod
+    def local_mlflow_tracker() -> str:
+        """Return local mlflow folder inside artifact store.
+
+        Returns:
+            MLFlow tracking uri for local backend.
+        """
+        dir_ = Directory(skip_repository_check=True)
+        artifact_store = dir_.active_stack.artifact_store
+        # TODO: MLFlow can connect to non-local stores however
+        # I am unsure what this entails and how to test this.
+        # AWS would be an interesting testbed for a future iteration.
+        # Ideally this would work for an arbitrary artifact store.
+
+        local_mlflow_uri = os.path.join(artifact_store.path, "mlruns")
+        if not os.path.exists(local_mlflow_uri):
+            os.makedirs(local_mlflow_uri)
+
+        return "file:" + local_mlflow_uri
+
+    def get_tracking_uri(self) -> str:
+        """Return configured MLFlow tracking uri.
+
+        Returns:
+            MLFlow tracking uri
+        
+        Raises:
+            ValueError: if tracking uri is empty and user didn't specify to use the local backend.
+        """
+        if self.tracking_uri:
+            return self.tracking_uri
+        else:
+            if self.use_local_backend:
+                return self.local_mlflow_tracker()
+            else:
+                raise ValueError(
+                    f"You must specify either a tracking uri or the use "
+                    f"of your local artifact store for the MLFlow "
+                    f"experiment tracker."
+                )
+
+    def prepare_step_run(self) -> None:
+        """Configure MLFlow tracking URI and credentials."""
+        if self.tracking_token:
+            os.environ[MLFLOW_TRACKING_TOKEN] = self.tracking_token
+        if self.tracking_username:
+            os.environ[MLFLOW_TRACKING_USERNAME] = self.tracking_username
+        if self.tracking_password:
+            os.environ[MLFLOW_TRACKING_PASSWORD] = self.tracking_password
+
+        mlflow.set_tracking_uri(self.get_tracking_uri())
+        return
+
+    def cleanup_step_run(self) -> None:
+        mlflow.set_tracking_uri("")
+
+    @property
+    def validator(self) -> Optional[StackValidator]:
+        """Validate that MLFlow config with the rest of stack is valid.
+
+        ..note: We just need to check (for now) that if the use local flag
+            is used that there is a local artifact store
+        """
+        if self.tracking_uri:
+            # Tracking URI exists so do nothing
+            return None
+        else:
+            # Presumably they've set the use_local_backend to true
+            # So check for local artifact store b/c thats all that
+            # works for now. This will be edited later (probably...)
+            return StackValidator(
+                custom_validation_function=lambda stack: (
+                    isinstance(stack.artifact_store, LocalArtifactStore),
+                    "MLFlow experiment tracker with local backend only "
+                    "works with a local artifact store at this time."
+                )
+            )
+
+
+    def active_experiment(self, experiment_name=None) -> Optional[Experiment]:
+        """Return currently active MLFlow experiment.
+
+        Args:
+            experiment_name: experiment name to set in MLFlow.
+
+        Returns:
+            None if not in step else will return an MLFlow Experiment
+        """
+        step_env = Environment().step_env
+
+        if not step_env:
+            # I.e. we are not in a step running
+            return None
+
+        experiment_name = experiment_name or step_env.pipeline_name
+        mlflow.set_experiment(experiment_name=experiment_name)
+        return mlflow.get_experiment_by_name(experiment_name)
+
+    def active_run(self, experiment_name=None) -> Optional[mlflow.ActiveRun]:
+        """"""
+        step_env = Environment().step_env
+        active_experiment = self.active_experiment(experiment_name)
+
+        if not active_experiment:
+            # This checks for experiment + not being in setp
+            # Should we make this explicit or keep it as implicit?
+            return None
+
+        experiment_id = self.active_experiment.experiment_id
+        # TODO: There may be race conditions in the below code for parallel
+        # steps. For example for HP tuning if two train steps are running
+        # and they both create a run then we send it onwards to a testing step
+        # which will now not know which run to use. We don't want a new run
+        # But rather to search for the most recent run. But even that might
+        # Have conflicts when there are multiple running steps that do this...
+        # How can we handle this?
+        # Naive Idea: How about each step has an identifier with it?
+        runs = mlflow.search_runs(
+            experiment_ids=[experiment_id],
+            filter_string=f'tags.mlflow.runName = "{step_env.pipeline_run_id}"',
+            output_format="list",
+        )
+
+        run_id = runs[0].info.run_if if runs else None
+
+        current_active_run = mlflow.active_run()
+        if current_active_run and current_active_run.info.run_id == run_id:
+            # Is not None AND run_id matches
+            return current_active_run
+
+        return mlflow.start_run(
+            run_id = run_id,
+            run_name=step_env.pipeline_run_id,
+            experiment_id=experiment_id,
+        )

--- a/src/coalescenceml/integrations/mlflow/mlflow_step_decorator.py
+++ b/src/coalescenceml/integrations/mlflow/mlflow_step_decorator.py
@@ -36,7 +36,6 @@ def enable_mlflow(
     ...
 
 
-@overload
 def enable_mlflow(
     step: S,
     experiment_name: Optional[str] = None,
@@ -121,7 +120,7 @@ def mlflow_entrypoint(
                 passthrough
             """
             experiment_tracker = Directory(
-                skip_repository_check=True,
+                skip_directory_check=True,
             ).active_stack.experiment_tracker
 
             if not isinstance(experiment_tracker, MLFlowExperimentTracker):
@@ -142,5 +141,5 @@ def mlflow_entrypoint(
         
         return cast(F, wrapper)
 
-    return innter_decorator
+    return inner_decorator
 

--- a/src/coalescenceml/integrations/mlflow/mlflow_step_decorator.py
+++ b/src/coalescenceml/integrations/mlflow/mlflow_step_decorator.py
@@ -1,0 +1,146 @@
+import functools
+from typing import Any, Callable, Optional, Type, TypeVar, Union, cast, overload
+
+from coalescenceml.directory import Directory
+from coalescenceml.environment import Environment
+from coalescenceml.integrations.mlflow.experiment_tracker import (
+    MLFlowExperimentTracker,
+)
+from coalescenceml.logger import get_logger
+from coalescenceml.step import BaseStep
+from coalescenceml.step.utils import STEP_INNER_FUNC_NAME
+
+logger = get_logger(__name__)
+
+
+# Entry point function type
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Step type
+S = TypeVar("S", bound=Type[BaseStep])
+
+
+@overload
+def enable_mlflow(
+    step: S,
+) -> S:
+    """Type annotation for no arguments."""
+    ...
+
+
+@overload
+def enable_mlflow(
+    experiment_name: str,
+) -> Callable[[S], S]:
+    """Type annotation for arguments."""
+    ...
+
+
+@overload
+def enable_mlflow(
+    step: S,
+    experiment_name: Optional[str] = None,
+) -> Union[S, Callable[[S], S]]:
+    """Decorator to enable MLFlow run for a step.
+
+    Args:
+        step: Step class to be decorated
+        experiment_name: Name of mlflow experiment to use. Defaults
+            to pipeline name
+
+    Returns:
+        A BaseStep with wrapped entrypoint functionality
+    """
+    def inner_decorator(step_: S) -> S:
+        """Decorate step entrypoint."""
+
+        logger.debug(
+            f"Applying MLFlow decorator to step {step_.__name__}"
+        )
+        if not issubclass(step_, BaseStep):
+            raise RuntimeError(
+                "The MLFlow decorator can only be applied to a BaseStep "
+                "subclass or a function decorated with @step from coml."
+            )
+
+        entrypoint_orig = getattr(step_, STEP_INNER_FUNC_NAME)
+        return cast(
+            S,
+            type(
+                step_.__name__,
+                (step_,),
+                {
+                    STEP_INNER_FUNC_NAME: staticmethod(
+                        mlflow_entrypoint(
+                            experiment_name=experiment_name,
+                        )(entrypoint_orig)
+                    ),
+                    "__module__": step_.__module__,
+                }
+            )
+        )
+
+    if step is None:
+        return inner_decorator
+    else:
+        return inner_decorator(step)
+
+
+def mlflow_entrypoint(
+    experiment_name: Optional[str] = None,
+) -> Callable[[F], F]:
+    """Build entrypoint for wandb experiment.
+
+    Args:
+        experiment_name:
+
+    Returns:
+        wrapped function with mlflow access
+    """
+    # TODO: Modify the experiment tracker to consider the
+    # project name as well as experiment name being passed
+    # in explicitly to the decorator.
+    def inner_decorator(func: F) -> F:
+        """Wrap function with wandb experiment tracker
+
+        Args:
+            func: function to wrap
+
+        Returns:
+            Wrapped function
+        """
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            """Wrap function.
+
+            Args:
+                *args: pass through
+                **kwargs: pass through
+
+            Returns:
+                passthrough
+            """
+            experiment_tracker = Directory(
+                skip_repository_check=True,
+            ).active_stack.experiment_tracker
+
+            if not isinstance(experiment_tracker, MLFlowExperimentTracker):
+                raise ValueError(
+                    "The active stack must have an MLFlow experiment tracker "
+                    "to be registered to be able to track experiments using "
+                    "MLFlow."
+            )
+
+            active_run = experiment_tracker.active_run(experiment_name=experiment_name)
+            if not active_run:
+                raise RuntimeError(
+                    "No active MLFlow run configured."
+                )
+
+            with active_run:
+                return func(*args, **kwargs)
+        
+        return cast(F, wrapper)
+
+    return innter_decorator
+

--- a/src/coalescenceml/integrations/wandb/__init__.py
+++ b/src/coalescenceml/integrations/wandb/__init__.py
@@ -1,0 +1,16 @@
+from coalescenceml.integrations.constants import WANDB
+from coalescenceml.integrations.integration import Integration
+
+
+class WandbIntegration(Integration):
+    """Integration for Wandb."""
+
+    NAME = WANDB
+    REQUIREMENTS = ["wandb==0.12.15"]
+
+    @classmethod
+    def activate(cls) -> None:
+        from coalescenceml.integrations.wandb import experiment_tracker
+
+
+WandbIntegration.check_installation()

--- a/src/coalescenceml/integrations/wandb/experiment_tracker/__init__.py
+++ b/src/coalescenceml/integrations/wandb/experiment_tracker/__init__.py
@@ -1,0 +1,3 @@
+from coalescenceml.integrations.wandb.experiment_tracker.wandb_experiment_tracker import (
+    WandbExperimentTracker,
+)

--- a/src/coalescenceml/integrations/wandb/experiment_tracker/wandb_experiment_tracker.py
+++ b/src/coalescenceml/integrations/wandb/experiment_tracker/wandb_experiment_tracker.py
@@ -1,0 +1,98 @@
+import os
+from contextlib import contextmanager
+from typing import ClassVar, Iterator, Optional, Tuple
+
+import wandb
+
+from coalescenceml.integrations.contants import WANDB
+from coalescenceml.logger import get_logger
+from coalescenceml.stack.stack_component_registry import (
+    register_stack_component_class,
+)
+
+logger = get_logger(__name__)
+
+WANDB_API_KEY = "WANDB_API_KEY"
+
+
+@register_stack_component_class
+class WandbExperimentTracker(BaseExperimentTracker):
+    """Store wandb configuration and execute logging.
+
+    ..note: One method of directly accessing the experiment
+        tracker is as follows with the StepContext....
+
+    ```python
+    from coalescenceml.step import StepContext
+
+
+    @enable_wandb
+    @step
+    def my_train_step(context: StepContext, ...):
+        context.stack.experiment_tracker # Get experiment tracker directly
+    ```
+
+    ..note: Otherwise directly using wand.log({"acc": 0.5}) will work
+        perfectly!
+
+    # TODO: Determine an easy way to access the experiment tracker and
+    # the corresponding helper functions without accessing the context.
+    # This might be an OK pattern but might be tough to remember
+    """
+
+    api_key: str
+    entity: Optional[str] = None
+    project_name: Optional[str] = None
+
+    FLAVOR: ClassVar[str] = WANDB
+
+    def prepare_step_run(self) -> None:
+        """Set the wandb API key."""
+        os.environ[WANDB_API_KEY] = self.api_key
+
+    def cleanup_step_run(self) -> None:
+        """Clean up wandb API key."""
+        os.environ.pop(WANDB_API_KEY, None)
+
+    @contextmanager
+    def with_wandb_run(
+        self,
+        run_name: str,
+        tags: Tuple[str, ...] = ()
+        settings: Optional[wandb.Settings] = None,
+    ) -> Iterator[None]:
+        """Activate wandb run for duration of context manager.
+
+        Anything logged to wandb that is run while this is active
+        will automatically log to the same wandb run configured
+        by the run name passed here.
+  
+        Args:
+            run_name: Name of the wandb run to create
+            tags: tags to attach to wandb run
+            settings: Additional settings for the wandb run
+        """
+        try:
+            logger.info(
+                f"Initializing wandb with project name: {self.project_name} "
+                f"run name: {run_name} entity: {self.entity}"
+            )
+            wandb.init(
+                project=self.project_name,
+                name=run_name,
+                entity=self.entity,
+                settings=settings,
+                tags=tags,
+            )
+            yield
+        finally:
+            wandb.finish()
+
+    def log_params(self, params: Dict[str, Any]) -> None:
+        wandb.config.update(params)
+
+    def log_metrics(self, metrics: Dict[str, Any]) -> None:
+        wandb.log(metrics)
+
+    def log_artifacts(self, artifacts: Dict[str, Any]) -> None:
+        raise NotImplementedError()

--- a/src/coalescenceml/integrations/wandb/experiment_tracker/wandb_experiment_tracker.py
+++ b/src/coalescenceml/integrations/wandb/experiment_tracker/wandb_experiment_tracker.py
@@ -58,7 +58,7 @@ class WandbExperimentTracker(BaseExperimentTracker):
     def with_wandb_run(
         self,
         run_name: str,
-        tags: Tuple[str, ...] = ()
+        tags: Tuple[str, ...] = (),
         settings: Optional[wandb.Settings] = None,
     ) -> Iterator[None]:
         """Activate wandb run for duration of context manager.

--- a/src/coalescenceml/integrations/wandb/wandb_step_decorator.py
+++ b/src/coalescenceml/integrations/wandb/wandb_step_decorator.py
@@ -1,0 +1,164 @@
+import functools
+from typing import Any, Callable, Optional, Type, TypeVar, Union, cast, overload
+
+import wandb
+
+from coalescenceml.directory import Directory
+from coalescenceml.environment import Environment
+from coalescenceml.integrations.wandb.experiment_tracker import (
+    WandbExperimentTracker,
+)
+from coalescenceml.logger import get_logger
+from coalescenceml.step import BaseStep
+from coalescenceml.step.utils import STEP_INNER_FUNC_NAME
+
+logger = get_logger(__name__)
+
+
+# Entry point function type
+F = TypeVar("F", bound=Callable[..., Any])
+
+# Step type
+S = TypeVar("S", bound=Type[BaseStep])
+
+
+@overload
+def enable_wandb(
+    step: S,
+) -> S:
+    """Type annotation for no arguments."""
+    ...
+
+
+@overload
+def enable_wandb(
+    *, settings: Optional[wandb.Settings] = None,
+) -> Callable[[S], S]:
+    """Type annotation for arguments."""
+    ...
+
+
+@overload
+def enable_wandb(
+    step: S,
+    *,
+    project_name: Optional[str] = None,
+    experiment_name: Optional[str] = None,
+    settings: Optional[wandb.Settings] = None,
+) -> Union[S, Callable[[S], S]]:
+    """Decorator to enable wandb run for a step.
+
+    Args:
+        step: Step class to be decorated
+        project_name: Name of project
+        experiment_name: Name of wandb experiment to use. Defaults
+            to pipeline name
+        settings: Wandb settings to set
+
+    Returns:
+        A BaseStep with wrapped entrypoint functionality
+    """
+    def inner_decorator(step_: S) -> S:
+        """Decorate step entrypoint."""
+
+        logger.debug(
+            f"Applying wandb decorator to step {step_.__name__}"
+        )
+        if not issubclass(step_, BaseStep):
+            raise RuntimeError(
+                "The wandb decorator can only be applied to a BaseStep "
+                "subclass or a function decorated with @step from coml."
+            )
+
+        entrypoint_orig = getattr(step_, STEP_INNER_FUNC_NAME)
+        return cast(
+            S,
+            type(
+                step_.__name__,
+                (step_,),
+                {
+                    STEP_INNER_FUNC_NAME: staticmethod(
+                        wandb_entrypoint(
+                            project_name=project_name,
+                            experiment_name=experiment_name,
+                            settings=settings
+                        )(entrypoint_orig)
+                    ),
+                    "__module__": step_.__module__,
+                }
+            )
+        )
+
+    if step is None:
+        return inner_decorator
+    else:
+        return inner_decorator(step)
+
+
+def wandb_entrypoint(
+    project_name: Optional[str] = None,
+    experiment_name: Optional[str] = None,
+    settings: Optional[wandb.Settings] = None,
+) -> Callable[[F], F]:
+    """Build entrypoint for wandb experiment.
+
+    Args:
+        project_name:
+        experiment_name:
+        settings:
+
+    Returns:
+        wrapped function with wandb access
+    """
+    # TODO: Modify the experiment tracker to consider the
+    # project name as well as experiment name being passed
+    # in explicitly to the decorator.
+    def inner_decorator(func: F) -> F:
+        """Wrap function with wandb experiment tracker
+
+        Args:
+            func: function to wrap
+
+        Returns:
+            Wrapped function
+        """
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            """Wrap function.
+
+            Args:
+                *args: pass through
+                **kwargs: pass through
+
+            Returns:
+                passthrough
+            """
+            step_env = Environment().step_environment
+            run_name = f"{step_env.pipeline_run_id}_{step_env.step_name}"
+            tags = (
+                step_env.pipeline_name,
+                step_env.pipeline_run_id,
+            )
+
+            experiment_tracker = Directory(
+                skip_repository_check=True,
+            ).active_stack.experiment_tracker
+
+            if not isinstance(experiment_tracker, WandbExperimentTracker):
+                raise ValueError(
+                    "The active stack must have a wandb experiment tracker "
+                    "to be registered to be able to track experiments using "
+                    "wandb."
+                )
+
+            with experiment_tracker.with_wandb_run(
+                run_name=run_name,
+                tags=tags,
+                settings = settings,
+            ):
+                return func(*args, **kwargs)
+        
+        return cast(F, wrapper)
+
+    return innter_decorator
+

--- a/src/coalescenceml/integrations/wandb/wandb_step_decorator.py
+++ b/src/coalescenceml/integrations/wandb/wandb_step_decorator.py
@@ -38,7 +38,6 @@ def enable_wandb(
     ...
 
 
-@overload
 def enable_wandb(
     step: S,
     *,
@@ -141,7 +140,7 @@ def wandb_entrypoint(
             )
 
             experiment_tracker = Directory(
-                skip_repository_check=True,
+                skip_directory_check=True,
             ).active_stack.experiment_tracker
 
             if not isinstance(experiment_tracker, WandbExperimentTracker):
@@ -160,5 +159,5 @@ def wandb_entrypoint(
         
         return cast(F, wrapper)
 
-    return innter_decorator
+    return inner_decorator
 

--- a/src/coalescenceml/logger.py
+++ b/src/coalescenceml/logger.py
@@ -19,8 +19,8 @@ class CustomFormatter(logging.Formatter):
     pink: str = "\x1b[35m"
     green: str = "\x1b[32m"
     blue: str = "\x1b[34m"
-    yellow: str = "\x1b[33;21m"
-    red: str = "\x1b[31;21m"
+    yellow: str = "\x1b[33m"
+    red: str = "\x1b[31m"
     bold_red: str = "\x1b[31;1m"
     purple: str = "\x1b[1;35m"
     reset: str = "\x1b[0m"
@@ -50,9 +50,9 @@ class CustomFormatter(logging.Formatter):
             A string formatted according to specifications.
         """
         log_fmt = (
-            self.COLORS[LoggingLevels[COML_LOGGING_VERBOSITY]] +
-            self.format_template +
-            self.reset
+            self.COLORS[LoggingLevels(log_record.levelno)]
+            + self.format_template
+            + self.reset
         )
 
         formatter = logging.Formatter(log_fmt)

--- a/src/coalescenceml/metadata_store/base_metadata_store.py
+++ b/src/coalescenceml/metadata_store/base_metadata_store.py
@@ -39,6 +39,7 @@ class BaseMetadataStore(StackComponent, ABC):
 
     # Class Configuration
     TYPE: ClassVar[StackComponentFlavor] = StackComponentFlavor.METADATA_STORE
+    FLAVOR: ClassVar[str]
 
     @property
     def store(self) -> metadata_store.MetadataStore:

--- a/src/coalescenceml/orchestrator/local_orchestrator.py
+++ b/src/coalescenceml/orchestrator/local_orchestrator.py
@@ -148,4 +148,6 @@ class LocalOrchestrator(BaseOrchestrator):
                 custom_driver_spec=custom_driver_spec,
                 custom_executor_operators=custom_executor_operators,
             )
+            stack.prepare_step_run()
             utils.execute_step(component_launcher)
+            stack.cleanup_step_run()

--- a/src/coalescenceml/stack/stack.py
+++ b/src/coalescenceml/stack/stack.py
@@ -27,10 +27,9 @@ from coalescenceml.utils import readability_utils
 if TYPE_CHECKING:
     from coalescenceml.artifact_store import BaseArtifactStore
     from coalescenceml.container_registry import BaseContainerRegistry
-
+    from coalescenceml.experiment_tracker import BaseExperimentTracker
     # from coalescenceml.feature_store import BaseFeatureStore
     from coalescenceml.metadata_store import BaseMetadataStore
-
     # from coalescenceml.model_deployer import BaseModelDeployer
     from coalescenceml.orchestrator import BaseOrchestrator
     from coalescenceml.pipeline import BasePipeline
@@ -67,6 +66,7 @@ class Stack:
         step_operator: Optional[BaseStepOperator] = None,
         # feature_store: Optional["BaseFeatureStore"] = None,
         # model_deployer: Optional["BaseModelDeployer"] = None,
+        experiment_tracker: Optional[BaseExperimentTracker] = None,
     ):
         """Initialize and validate a stack instance.
 
@@ -77,6 +77,7 @@ class Stack:
             artifact_store: Artifact store instance to be used in stack
             container_registry: Container registry instance to be used in stack
             step_operator: Step operator instance to be used in stack
+            experiment_tracker: Experiment tracker instance to be used
         """
         self._name = name
         self._orchestrator = orchestrator
@@ -87,6 +88,7 @@ class Stack:
         self._secrets_manager = None  # secrets_manager
         self._feature_store = None  # feature_store
         self._model_deployer = None  # model_deployer
+        self._experiment_tracker = experiment_tracker
 
         self.validate()
 
@@ -105,13 +107,11 @@ class Stack:
         """
         from coalescenceml.artifact_store import BaseArtifactStore
         from coalescenceml.container_registry import BaseContainerRegistry
-
+        from coalescenceml.experiment_tracker import BaseExperimentTracker
         # from coalescenceml.feature_store import BaseFeatureStore
         from coalescenceml.metadata_store import BaseMetadataStore
-
         # from coalescenceml.model_deployer import BaseModelDeployer
         from coalescenceml.orchestrator import BaseOrchestrator
-
         # from coalescenceml.secrets_manager import BaseSecretsManager
         from coalescenceml.step_operator import BaseStepOperator
 
@@ -153,6 +153,14 @@ class Stack:
         ):
             _raise_type_error(container_registry, BaseContainerRegistry)
 
+        experiment_tracker = components.get(
+            StackComponentFlavor.EXPERIMENT_TRACKER
+        )
+        if experiment_tracker is not None and not isinstance(
+            experiment_tracker, BaseExperimentTracker
+        ):
+            _raise_type_error(experiment_tracker, BaseExperimentTracker)
+
         # secrets_manager = components.get(
         #     StackComponentFlavor.SECRETS_MANAGER
         # )
@@ -189,6 +197,7 @@ class Stack:
             step_operator=step_operator,
             # feature_store=feature_store,
             # model_deployer=model_deployer,
+            experiment_tracker=experiment_tracker,
         )
 
     @classmethod
@@ -247,6 +256,7 @@ class Stack:
                 self._step_operator,
                 self._feature_store,
                 self._model_deployer,
+                self._experiment_tracker,
             ]
             if component is not None
         }
@@ -319,6 +329,15 @@ class Stack:
     # def model_deployer(self) -> Optional["BaseModelDeployer"]:
     #     """The model deployer of the stack."""
     #     return self._model_deployer
+
+    @property
+    def experiment_tracker(self) -> Optional[BaseExperimentTracker]:
+        """Fetch experiment tracker of the stack.
+
+        Returns:
+            experiment tracker within the stack
+        """
+        return self._experiment_tracker
 
     @property
     def runtime_options(self) -> Dict[str, Any]:
@@ -466,6 +485,16 @@ class Stack:
             component.cleanup_pipeline_run()
 
         return return_value
+
+    def prepare_step_run(self) -> None:
+        """Prepare running a step."""
+        for component in self.components.values():
+            component.prepare_step_run()
+
+    def cleanup_step_run(self) -> None:
+        """Cleanup resources after step is run."""
+        for component in self.components.values():
+            component.cleanup_step_run()
 
     @property
     def is_provisioned(self) -> bool:

--- a/src/coalescenceml/stack/stack_component.py
+++ b/src/coalescenceml/stack/stack_component.py
@@ -83,6 +83,12 @@ class StackComponent(BaseModel, ABC):
     def cleanup_pipeline_run(self) -> None:
         """Cleans up resources after the pipeline run is finished."""
 
+    def prepare_step_run(self) -> None:
+        """Prepare running a step."""
+
+    def cleanup_step_run(self) -> None:
+        """Cleanup resources after the step is run."""
+
     @property
     def validator(self) -> Optional["StackValidator"]:
         """The optional validator of the stack component.


### PR DESCRIPTION
# Overview
This PR adds a new stack component, the `experiment_tracker` which will allow us to configure our experiment tracking tools to work with Coalescence. Examples are wandb and mlflow.

## Changes
- Added new stack component (`experiment_tracker`)
- Added corresponding CLI and stack commands for Experiment trackers
- Added new prepare step and cleanup step for experiment configuration
- WandbExperimentTracker integration added

## API Updates
- Added experiment racket everywhere there is a stack (i.e. in stack and in CLI)

### New Features *(required)*
- Added new ExperimentTracker interface
- Wandb Experiment tracking interface

### Deprecations *(required)*
- N/A

### Enhancements *(required)*

## Checklist
- [ ] Interrogate has > 70% coverage
- [ ] All tests have passed (new tests are made)
- [ ] Total test coverage > 75%
- [ ] New code test coverage > 80%
- [ ] Pass all linting checks

## References

