### PR TITLE
Feature/eng 00012 impoer expeort stack

### DIFF
--- a/src/coalescenceml/cli/stack.py
+++ b/src/coalescenceml/cli/stack.py
@@ -2,6 +2,7 @@ from typing import Optional
 
 import click
 
+import coalescenceml
 from coalescenceml.cli import utils as cli_utils
 from coalescenceml.cli.cli import cli
 from coalescenceml.config.global_config import GlobalConfiguration
@@ -102,6 +103,7 @@ def register_stack(
 ) -> None:
     """Register a stack."""
     _register_stack_helper(
+        stack_name=stack_name,
         metadata_store_name=metadata_store_name,
         artifact_store_name=artifact_store_name,
         orchestrator_name=orchestrator_name,
@@ -406,14 +408,16 @@ def export_stack(stack_name: str, filepath: str) -> None:
                     for key, value in component.dict().items()
                     if key != "uuid" and value is not None
                 }
+                print(component_type)
+                print(str(component_type))
                 component_dict["flavor"] = component.FLAVOR
                 component_data[str(component_type)] = component_dict
 
     # Write out coalescence info as well to YAML
     yaml_data = {
-        "coalescenceml_verion": coalescenceml.__version__,
+        "coalescenceml_version": coalescenceml.__version__,
         "stack_name": stack_name,
-        "components": component_dict,
+        "components": component_data,
     }
 
     filepath = filepath or f"{stack_name}-config.yaml"
@@ -447,4 +451,4 @@ def import_stack(filepath: str) -> None:
         )
         component = component_class(**component_config) # Auto ignores unused kwargs
         Directory().register_stack_component(component)
-    _register_stack(stack_name=stack_name, **component_data)
+    _register_stack_helper(stack_name=stack_name, **component_data)

--- a/src/coalescenceml/cli/stack.py
+++ b/src/coalescenceml/cli/stack.py
@@ -439,6 +439,9 @@ def import_stack(filepath: str) -> None:
         )
         return
 
+    # TODO: Check if any of these components are registered. If so, then
+    # Skip the check. However if they have the same name but different config
+    # then we should raise a helpful error message.
     # register components and stack
     stack_name = yaml_data["stack_name"]
     component_data = {}

--- a/src/coalescenceml/cli/stack.py
+++ b/src/coalescenceml/cli/stack.py
@@ -28,7 +28,6 @@ def stack() -> None:
     """Stacks to define various environments."""
 
 
-
 @stack.command("register", context_settings=dict(ignore_unknown_options=True))
 @click.argument("stack_name", type=str, required=True)
 @click.option(
@@ -130,7 +129,7 @@ def register_stack_helper(
     step_operator_name: Optional[str] = None,
     feature_store_name: Optional[str] = None,
     model_deployer_name: Optional[str] = None,
-)-> None:
+) -> None:
     cli_utils.print_active_profile()
 
     with console.status(f"Registering stack '{stack_name}'...\n"):
@@ -434,7 +433,7 @@ def export_stack(stack_name: Optional[str], filepath: Optional[str]) -> None:
 def import_component_helper(
     component_flavor: StackComponentFlavor, component_config: Dict[str, str],
 ) -> str:
-    """ """
+    """ Return the name of a component if it exists """
     component_type = StackComponentFlavor(component_flavor)
     component_name = component_config.pop("name")
     component_flavor = component_config.pop("flavor")
@@ -462,7 +461,6 @@ def import_component_helper(
         if found_component:
             return component_name
 
-
         # Component exists so must be renamed
         display_name = component_display_name_helper(
             component_type
@@ -484,7 +482,6 @@ def import_component_helper(
     return component_name
 
 
-
 @stack.command("import")
 @click.argument("filepath", type=str, required=True)
 def import_stack(filepath: str) -> None:
@@ -500,7 +497,6 @@ def import_stack(filepath: str) -> None:
             f"while the current version of CoalescenceML is {coalescenceml.__version__}."
         )
         return
-
 
     dir_ = Directory()
     registered_stacks = {

--- a/src/coalescenceml/cli/stack_components.py
+++ b/src/coalescenceml/cli/stack_components.py
@@ -1,6 +1,6 @@
 import time
 from importlib import import_module
-from typing import Callable, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 import click
 from rich.markdown import Markdown
@@ -14,7 +14,7 @@ from coalescenceml.directory import Directory
 from coalescenceml.stack import StackComponent
 
 
-def _component_display_name(
+def component_display_name_helper(
     component_type: StackComponentFlavor
 ) -> str:
     """Human-readable name for a stack component."""
@@ -50,6 +50,25 @@ def _get_stack_component(
     )
     return component
 
+def register_stack_component_helper(
+    component_type: StackComponentFlavor,
+    component_name: str,
+    component_flavor: str,
+    **kwargs: Dict[str, Any],
+) -> None:
+    """Register a stack component helper."""
+    from coalescenceml.stack.stack_component_class_registry import (
+        StackComponentClassRegistry,
+    )
+
+    component_cls = StackComponentClassRegistry.get_class(
+        component_type=component_type,
+        component_flavor=component_flavor,
+    )
+
+    component = component_cls(name=component_name, **kwargs)
+    Directory().register_stack_component(component)
+
 
 def generate_stack_component_get_command(
     component_type: StackComponentFlavor,
@@ -64,7 +83,7 @@ def generate_stack_component_get_command(
 
         active_stack = Directory().active_stack
         component = active_stack.components.get(component_type, None)
-        display_name = _component_display_name(component_type)
+        display_name = component_display_name_helper(component_type)
         if component:
             cli_utils.info(f"Active {display_name}: '{component.name}'")
         else:
@@ -90,7 +109,7 @@ def generate_stack_component_describe_command(
         cli_utils.print_active_profile()
         cli_utils.print_active_stack()
 
-        display_name = _component_display_name(component_type)
+        display_name = component_display_name_helper(component_type)
         dir_ = Directory()
         components = dir_.get_stack_components(component_type)
         if len(components) == 0:
@@ -142,7 +161,7 @@ def generate_stack_component_list_command(
         dir_ = Directory()
 
         components = dir_.get_stack_components(component_type)
-        display_name = _component_display_name(component_type)
+        display_name = component_display_name_helper(component_type)
         if len(components) == 0:
             cli_utils.warning(f"No {display_name} registered.")
             return
@@ -164,7 +183,7 @@ def generate_stack_component_register_command(
     component_type: StackComponentFlavor,
 ) -> Callable[[str, str, List[str]], None]:
     """Generates a `register` command for the specific stack component type."""
-    display_name = _component_display_name(component_type)
+    display_name = component_display_name_helper(component_type)
 
     @click.argument(
         "name",
@@ -191,15 +210,14 @@ def generate_stack_component_register_command(
             cli_utils.error(str(e))
             return
 
-        from coalescenceml.stack.stack_component_class_registry import (
-            StackComponentClassRegistry,
+
+        register_stack_component_helper(
+            component_type=component_type,
+            component_name=component_name,
+            component_flavor=component_flavor,
+            **parsed_args,
         )
 
-        component_class = StackComponentClassRegistry.get_class(
-            component_type=component_type, component_flavor=flavor
-        )
-        component = component_class(name=name, **parsed_args)
-        Directory().register_stack_component(component)
         cli_utils.info(f"Successfully registered {display_name} `{name}`.")
 
     return register_stack_component_command
@@ -218,7 +236,7 @@ def generate_stack_component_delete_command(
             component_type=component_type,
             name=name,
         )
-        display_name = _component_display_name(component_type)
+        display_name = component_display_name_helper(component_type)
         cli_utils.info(f"Deleted {display_name}: {name}")
 
     return delete_stack_component_command
@@ -236,7 +254,7 @@ def generate_stack_component_up_command(
         cli_utils.print_active_stack()
 
         component = _get_stack_component(component_type, component_name=name)
-        display_name = _component_display_name(component_type)
+        display_name = component_display_name_helper(component_type)
 
         if component.is_running:
             cli_utils.info(
@@ -288,7 +306,7 @@ def generate_stack_component_down_command(
         cli_utils.print_active_stack()
 
         component = _get_stack_component(component_type, component_name=name)
-        display_name = _component_display_name(component_type)
+        display_name = component_display_name_helper(component_type)
 
         if component.is_running and not force:
             cli_utils.info(
@@ -339,7 +357,7 @@ def generate_stack_component_logs_command(
         cli_utils.print_active_stack()
 
         component = _get_stack_component(component_type, component_name=name)
-        display_name = _component_display_name(component_type)
+        display_name = component_display_name_helper(component_type)
         log_file = component.log_file
 
         if not log_file or not fileio.exists(log_file):
@@ -399,7 +417,7 @@ def register_single_stack_component_cli_commands(
 ) -> None:
     """Registers all basic stack component CLI commands."""
     command_name = component_type.value.replace("_", "-")
-    display_name = _component_display_name(component_type)
+    display_name = component_display_name_helper(component_type)
 
     @parent_group.group(
         command_name, help=f"Commands to interact with {display_name}."

--- a/src/coalescenceml/enums.py
+++ b/src/coalescenceml/enums.py
@@ -9,6 +9,8 @@ class DictEnum(str, Enum):
     ..note: This is a subclass of str as well for nice properties with respect
         to logging.
     """
+    def __str__(self)->str:
+        return self.value
 
     @classmethod
     def names(cls) -> List[str]:


### PR DESCRIPTION
# Overview
Added the ability to now export and import stack components along with entire stacks via the CLI.

## Changes
- Added new `stack export` and `stack import` commands

## API Updates
- CLI has new commands for stack group
    - `stack export` generates YAML on stack configuration
    - `stack import` loads YAML to create a stack

### New Features *(required)*

### Deprecations *(required)*

### Enhancements *(required)*

## Checklist
- [ ] Interrogate has > 70% coverage
- [ ] All tests have passed (new tests are made)
- [ ] Total test coverage > 75%
- [ ] New code test coverage > 80%
- [ ] Pass all linting checks

## References

